### PR TITLE
Rename initial CH4 parameter in forcing component

### DIFF
--- a/src/MimiHECTOR.jl
+++ b/src/MimiHECTOR.jl
@@ -75,7 +75,7 @@ function get_hectorch4(;rcp_scenario::String="RCP85", start_year::Int64=1765, en
 
     # ---- Methane Radiative Forcing ---- #
     set_param!(m, :rf_ch4, :N₂O_0, N₂O_0)
-    set_param!(m, :rf_ch4, :CH4_0, CH₄_0)
+    set_param!(m, :rf_ch4, :CH₄_0, CH₄_0)
     set_param!(m, :rf_ch4, :scale_CH₄, 1.0)
 
     # ---- Straospheric Water Vapor From Methane Radiative Forcing ---- #

--- a/src/components/rf_ch4.jl
+++ b/src/components/rf_ch4.jl
@@ -10,7 +10,7 @@ end
 
 @defcomp rf_ch4 begin
     N₂O_0     = Parameter()             # Pre-industrial atmospheric nitrous oxide concentration (ppb).
-    CH4_0     = Parameter()             # Pre-industrial atmospheric methane concentration (ppb).
+    CH₄_0     = Parameter()             # Pre-industrial atmospheric methane concentration (ppb).
     scale_CH₄ = Parameter()             # Scaling factor for uncertainty in methane radiative forcing.
     CH4       = Parameter(index=[time]) # Atmospheric methane concentration (ppb).
 
@@ -19,6 +19,6 @@ end
     function run_timestep(p, v, d, t)
 
         # Direct methane radiative forcing.
-        v.rf_CH4[t] = (0.036 * (sqrt(p.CH4[t]) - sqrt(p.CH4_0)) - (interact(p.CH4[t], p.N₂O_0) - interact(p.CH4_0, p.N₂O_0))) * p.scale_CH₄
+        v.rf_CH4[t] = (0.036 * (sqrt(p.CH4[t]) - sqrt(p.CH₄_0)) - (interact(p.CH4[t], p.N₂O_0) - interact(p.CH₄_0, p.N₂O_0))) * p.scale_CH₄
     end
 end


### PR DESCRIPTION
Rename a parameter to match updated radiative forcing components.